### PR TITLE
fix: properly expand env variables

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -83,7 +83,7 @@ func (p *Plugin) Init() error { //nolint:gocognit,gocyclo
 				p.viper.Set(key, val)
 			}
 
-			// we should set a whole array
+			// we should set the whole array
 			if len(strArr) > 0 {
 				p.viper.Set(key, strArr)
 			}

--- a/plugin.go
+++ b/plugin.go
@@ -77,9 +77,10 @@ func (p *Plugin) Init() error { //nolint:gocognit,gocyclo
 			for i := 0; i < len(t); i++ {
 				if valStr, ok := t[i].(string); ok {
 					strArr = append(strArr, os.ExpandEnv(valStr))
-				} else {
-					p.viper.Set(key, os.ExpandEnv(valStr))
+					continue
 				}
+
+				p.viper.Set(key, val)
 			}
 
 			// we should set a whole array

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,10 +1,39 @@
 package config
 
 import (
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestEnvArr(t *testing.T) {
+	require.NoError(t, syscall.Setenv("REDIS_HOST_1", "localhost:2999"))
+	require.NoError(t, syscall.Setenv("REDIS_HOST_2", "localhost:2998"))
+	p := &Plugin{
+		Prefix:  "rr",
+		Path:    "tests/.rr-env-arr.yaml",
+		Version: "2.11.3",
+	}
+
+	err := p.Init()
+	require.NoError(t, err)
+
+	str := p.viper.Get("redis.addrs")
+	if _, ok := str.([]string); !ok {
+		t.Fatal("not a slice")
+	}
+
+	require.Len(t, str.([]string), 2)
+
+	if str.([]string)[0] != "localhost:2999" && str.([]string)[0] != "localhost:2998" {
+		t.Fatalf("not expanded")
+	}
+
+	if str.([]string)[1] != "localhost:2999" && str.([]string)[1] != "localhost:2998" {
+		t.Fatalf("not expanded")
+	}
+}
 
 func TestVersions(t *testing.T) {
 	// rr 2.8, config 2.7

--- a/tests/.rr-env-arr.yaml
+++ b/tests/.rr-env-arr.yaml
@@ -1,0 +1,31 @@
+version: "2.7"
+
+rpc:
+  listen: tcp://127.0.0.1:6001
+
+server:
+  command: "php ../rr-e2e-tests/php_test_files/psr-worker-bench.php"
+  relay: pipes
+
+http:
+  address: 127.0.0.1:15389
+  middleware:
+    - "sendfile"
+  pool:
+    allocate_timeout: 10s
+    num_workers: 2
+
+redis:
+  addrs:
+    - "${REDIS_HOST_1}"
+    - "${REDIS_HOST_2}"
+
+kv:
+  test-redis:
+    driver: redis
+    config: {}
+
+logs:
+  encoding: console
+  level: debug
+  mode: production


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1308

## Description of Changes

- Properly replace `[]any` types of env variables.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
