### PR TITLE
Apply env expansion consistently by moving it into a decode hook

### DIFF
--- a/expand.go
+++ b/expand.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"strings"
-
-	"github.com/spf13/viper"
 )
 
 // ExpandVal replaces ${var} or $var in the string based on the mapping function.
@@ -84,35 +82,6 @@ func getShellName(s string) (string, int) {
 
 	}
 	return s[:i], i
-}
-
-func expandEnvViper(v *viper.Viper) {
-	for _, key := range v.AllKeys() {
-		val := v.Get(key)
-		switch t := val.(type) {
-		case string:
-			// for string expand it
-			v.Set(key, parseEnvDefault(t))
-		case []any:
-			// for slice -> check if it's a slice of strings
-			strArr := make([]string, 0, len(t))
-			for i := 0; i < len(t); i++ {
-				if valStr, ok := t[i].(string); ok {
-					strArr = append(strArr, parseEnvDefault(valStr))
-					continue
-				}
-
-				v.Set(key, val)
-			}
-
-			// we should set the whole array
-			if len(strArr) > 0 {
-				v.Set(key, strArr)
-			}
-		default:
-			v.Set(key, val)
-		}
-	}
 }
 
 // isShellSpecialVar reports whether the character identifies a special

--- a/go.work.sum
+++ b/go.work.sum
@@ -444,6 +444,7 @@ golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -514,6 +515,7 @@ golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk
 golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
+golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.122.0 h1:zDobeejm3E7pEG1mNHvdxvjs5XJoCMzyNH+CmwL94Es=

--- a/include.go
+++ b/include.go
@@ -26,15 +26,15 @@ func getConfiguration(path string) (map[string]any, string, error) {
 		return nil, "", errors.Errorf("type of version should be string, actual: %T", ver)
 	}
 
-	// automatically inject ENV variables using ${ENV} pattern
-	expandEnvViper(v)
-
 	return v.AllSettings(), ver.(string), nil
 }
 
 func (p *Plugin) handleInclude(rootVersion string) error {
-	ifiles := p.viper.GetStringSlice(includeKey)
-	if ifiles == nil {
+	var ifiles []string
+	if err := p.viper.UnmarshalKey(includeKey, &ifiles, p.unmarshalOpts()); err != nil {
+		return err
+	}
+	if len(ifiles) == 0 {
 		return nil
 	}
 
@@ -58,7 +58,10 @@ func (p *Plugin) handleInclude(rootVersion string) error {
 }
 
 func (p *Plugin) handleEnvFile() error {
-	envFile := p.viper.GetString(envFileKey)
+	var envFile string
+	if err := p.viper.UnmarshalKey(envFileKey, &envFile, p.unmarshalOpts()); err != nil {
+		return err
+	}
 	if envFile != "" {
 		dir, _ := filepath.Split(p.Path)
 		return godotenv.Load(filepath.Join(dir, envFile))


### PR DESCRIPTION
# Reason for This PR

Addresses https://github.com/roadrunner-server/roadrunner/issues/1989 and likely other sources of confusion where certain strings in the config file might not have been getting the expand-env-with-default treatment.

## Description of Changes

The code before this change iterates through configuration values with viper's AllKeys() method, and tries to apply the env expansion in cases it understands. However, AllKeys() doesn't descend into sequences/slices, which the previous code tried to handle by checking if the slice contained strings, but its also possible to have slices of more complex values, e.g. subobjects, which would be completely ignored by this case.

By moving the logic for expanding environment variables into the unmarshal decoder, it is applied to any string encountered during unmarshaling (at least I think thats the case based on my reading of how viper does things).

This will cause problems if other plugins apply their own form of env expansion, e.g. the server plugin doing its own os.Expand() on environment variable values. So this is probably a breaking change, and at the very least requires the server plugin to be updated accordingly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
