### PR TITLE
Add slice override from flags

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -76,12 +76,20 @@ func (p *Plugin) Init() error {
 
 	// override config Flags
 	if len(p.Flags) > 0 {
+		flagValues := make(map[string][]string, len(p.Flags))
 		for _, f := range p.Flags {
 			key, val, errP := parseFlag(f)
 			if errP != nil {
 				return errors.E(op, errP)
 			}
-			p.viper.Set(key, parseEnvDefault(val))
+			flagValues[key] = append(flagValues[key], parseEnvDefault(val))
+		}
+		for key, val := range flagValues {
+			if len(val) == 1 {
+				p.viper.Set(key, val[0])
+			} else {
+				p.viper.Set(key, val)
+			}
 		}
 	}
 

--- a/tests/configs/.rr-slice-config.yaml
+++ b/tests/configs/.rr-slice-config.yaml
@@ -1,0 +1,6 @@
+version: '3'
+
+http:
+  address: '0.0.0.0:8080'
+  middleware:
+    - static

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -731,3 +731,15 @@ func TestConfigEnvPriorityWithEnvFile(t *testing.T) {
 	// OS env has higher priority then .env file
 	assert.Equal(t, "debug", p.Get("logs.level"))
 }
+
+func TestOverrideSlices(t *testing.T) {
+	p := &configImpl.Plugin{
+		Path:  "configs/.rr-slice-config.yaml",
+		Flags: []string{"http.middleware=headers", "http.middleware=gzip"},
+	}
+
+	err := p.Init()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"headers", "gzip"}, p.Get("http.middleware"))
+}


### PR DESCRIPTION
# Reason for This PR

Problem with override `http.middleware` by Flags (we used octane laravel)

## Description of Changes

Add support several same flag (ex. `... -o http.middleware=headers -o http.middleware=static ...`)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for providing multiple values for the same configuration flag, allowing flags to override configuration keys with multiple values as a list.
- **Tests**
  - Introduced a new test to verify that multiple flag overrides for a configuration key are correctly accumulated into a list.
- **Chores**
  - Added a sample configuration file for testing slice-type configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->